### PR TITLE
Improve Authentication Options (#580)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ tester.py
 tags
 .idea/
 tile.jpg
+/env/
+/.project
+/.pydevproject
+/.settings/
+/env27/

--- a/owslib/coverage/wcs100.py
+++ b/owslib/coverage/wcs100.py
@@ -32,6 +32,7 @@ class WebCoverageService_1_0_0(WCSBase):
     """Abstraction for OGC Web Coverage Service (WCS), version 1.0.0
     Implements IWebCoverageService.
     """
+
     def __getitem__(self,name):
         ''' check contents dictionary to allow dict like access to service layers'''
         if name in self.__getattribute__('contents').keys():
@@ -39,12 +40,13 @@ class WebCoverageService_1_0_0(WCSBase):
         else:
             raise KeyError("No content named %s" % name)
     
-    def __init__(self,url,xml, cookies):
+    def __init__(self,url,xml, cookies, auth=None):
+        super(WebCoverageService_1_0_0, self).__init__(auth)
         self.version='1.0.0'
         self.url = url   
         self.cookies=cookies
         # initialize from saved capability document or access the server
-        reader = WCSCapabilitiesReader(self.version, self.cookies)
+        reader = WCSCapabilitiesReader(self.version, self.cookies, self.auth)
         if xml:
             self._capabilities = reader.readString(xml)
         else:
@@ -87,8 +89,7 @@ class WebCoverageService_1_0_0(WCSBase):
         #exceptions
         self.exceptions = [f.text for f \
                 in self._capabilities.findall('Capability/Exception/Format')]
-    
-    
+
     def items(self):
         '''supports dict-like items() access'''
         items=[]
@@ -161,12 +162,8 @@ class WebCoverageService_1_0_0(WCSBase):
         if log.isEnabledFor(logging.DEBUG):
             log.debug('WCS 1.0.0 DEBUG: Second part of URL: %s'%data)
         
-        
-        u=openURL(base_url, data, method, self.cookies)
-
+        u = openURL(base_url, data, method, self.cookies, auth=self.auth)
         return u
-    
-
                
     def getOperationByName(self, name):
         """Return a named operation item."""

--- a/owslib/coverage/wcs110.py
+++ b/owslib/coverage/wcs110.py
@@ -54,12 +54,13 @@ class WebCoverageService_1_1_0(WCSBase):
         else:
             raise KeyError("No content named %s" % name)
     
-    def __init__(self,url,xml, cookies):
+    def __init__(self,url,xml, cookies, auth=None):
+        super(WebCoverageService_1_1_0, self).__init__(auth=auth)
         
         self.url = url   
         self.cookies=cookies
         # initialize from saved capability document or access the server
-        reader = WCSCapabilitiesReader(self.version)
+        reader = WCSCapabilitiesReader(self.version, self.cookies, self.auth)
         if xml:
             self._capabilities = reader.readString(xml)
         else:
@@ -192,7 +193,7 @@ class WebCoverageService_1_1_0(WCSBase):
         if gridoffsets:
             request['gridoffsets']=gridoffsets
        
-       #anything else e.g. vendor specific parameters must go through kwargs
+        #anything else e.g. vendor specific parameters must go through kwargs
         if kwargs:
             for kw in kwargs:
                 request[kw]=kwargs[kw]
@@ -200,7 +201,7 @@ class WebCoverageService_1_1_0(WCSBase):
         #encode and request
         data = urlencode(request)
         
-        u=openURL(base_url, data, method, self.cookies)
+        u = openURL(base_url, data, method, self.cookies, auth=self.auth)
         return u
         
         

--- a/owslib/coverage/wcs200.py
+++ b/owslib/coverage/wcs200.py
@@ -48,13 +48,14 @@ class WebCoverageService_2_0_0(WCSBase):
         else:
             raise KeyError("No content named %s" % name)
 
-    def __init__(self,url,xml, cookies):
+    def __init__(self,url,xml, cookies, auth=None):
+        super(WebCoverageService_2_0_0, self).__init__(auth=auth)
         self.version='2.0.0'
         self.url = url
         self.cookies=cookies
         self.ows_common = OwsCommon(version='2.0.0')
         # initialize from saved capability document or access the server
-        reader = WCSCapabilitiesReader(self.version, self.cookies)
+        reader = WCSCapabilitiesReader(self.version, self.cookies, self.auth)
         if xml:
             self._capabilities = reader.readString(xml)
         else:
@@ -175,8 +176,7 @@ class WebCoverageService_2_0_0(WCSBase):
         if log.isEnabledFor(logging.DEBUG):
             log.debug('WCS 2.0.0 DEBUG: Second part of URL: %s'%data)
 
-        u=openURL(base_url, data, method, self.cookies)
-
+        u = openURL(base_url, data, method, self.cookies, auth=self.auth)
         return u
 
     def is_number(self,s):

--- a/owslib/coverage/wcs201.py
+++ b/owslib/coverage/wcs201.py
@@ -48,13 +48,14 @@ class WebCoverageService_2_0_1(WCSBase):
         else:
             raise KeyError("No content named %s" % name)
 
-    def __init__(self,url,xml, cookies):
+    def __init__(self,url,xml, cookies, auth=None):
+        super(WebCoverageService_2_0_1, self).__init__(auth=auth)
         self.version='2.0.1'
         self.url = url
         self.cookies=cookies
         self.ows_common = OwsCommon(version='2.0.1')
         # initialize from saved capability document or access the server
-        reader = WCSCapabilitiesReader(self.version, self.cookies)
+        reader = WCSCapabilitiesReader(self.version, self.cookies, self.auth)
         if xml:
             self._capabilities = reader.readString(xml)
         else:
@@ -175,8 +176,7 @@ class WebCoverageService_2_0_1(WCSBase):
         if log.isEnabledFor(logging.DEBUG):
             log.debug('WCS 2.0.1 DEBUG: Second part of URL: %s'%data)
 
-        u=openURL(base_url, data, method, self.cookies)
-
+        u = openURL(base_url, data, method, self.cookies, auth=self.auth)
         return u
 
     def is_number(self,s):

--- a/owslib/csw.py
+++ b/owslib/csw.py
@@ -24,8 +24,6 @@ try:                    # Python 3
 except ImportError:     # Python 2
     from urllib import urlencode
 
-from owslib.util import OrderedDict
-
 from owslib.etree import etree
 from owslib import fes
 from owslib import util
@@ -35,7 +33,7 @@ from owslib.fgdc import Metadata
 from owslib.dif import DIF
 from owslib.gm03 import GM03
 from owslib.namespaces import Namespaces
-from owslib.util import cleanup_namespaces, bind_url, add_namespaces, openURL
+from owslib.util import cleanup_namespaces, bind_url, add_namespaces, OrderedDict, Authentication, openURL, http_post
 
 # default variables
 outputformat = 'application/xml'
@@ -50,7 +48,7 @@ schema_location = '%s %s' % (namespaces['csw'], schema)
 class CatalogueServiceWeb(object):
     """ csw request class """
     def __init__(self, url, lang='en-US', version='2.0.2', timeout=10, skip_caps=False,
-                 username=None, password=None):
+                 username=None, password=None, auth=None):
         """
 
         Construct and process a GetCapabilities request
@@ -65,15 +63,19 @@ class CatalogueServiceWeb(object):
         - skip_caps: whether to skip GetCapabilities processing on init (default is False)
         - username: username for HTTP basic authentication
         - password: password for HTTP basic authentication
+        - auth: instance of owslib.util.Authentication
 
         """
-
+        if auth:
+            if username:
+                auth.username = username
+            if password:
+                auth.password = password
         self.url = util.clean_ows_url(url)
         self.lang = lang
         self.version = version
         self.timeout = timeout
-        self.username = username
-        self.password = password
+        self.auth = auth or Authentication(username, password)
         self.service = 'CSW'
         self.exceptionreport = None
         self.owscommon = ows.OwsCommon('1.0.0')
@@ -93,15 +95,15 @@ class CatalogueServiceWeb(object):
                 # ServiceIdentification
                 val = self._exml.find(util.nspath_eval('ows:ServiceIdentification', namespaces))
                 if val is not None:
-                  self.identification = ows.ServiceIdentification(val,self.owscommon.namespace)
+                    self.identification = ows.ServiceIdentification(val,self.owscommon.namespace)
                 else:
-                  self.identification = None
+                    self.identification = None
                 # ServiceProvider
                 val = self._exml.find(util.nspath_eval('ows:ServiceProvider', namespaces))
                 if val is not None:
                     self.provider = ows.ServiceProvider(val,self.owscommon.namespace)
                 else:
-                  self.provider = None
+                    self.provider = None
                 # ServiceOperations metadata 
                 self.operations = []
                 for elem in self._exml.findall(util.nspath_eval('ows:OperationsMetadata/ows:Operation', namespaces)):
@@ -385,7 +387,7 @@ class CatalogueServiceWeb(object):
             self.results['returned'] = int(util.testXMLValue(val, True))
             val = self._exml.find(util.nspath_eval('csw:SearchResults', namespaces)).attrib.get('nextRecord')
             if val is not None:
-                 self.results['nextrecord'] = int(util.testXMLValue(val, True))
+                self.results['nextrecord'] = int(util.testXMLValue(val, True))
             else:
                 warnings.warn("""CSW Server did not supply a nextRecord value (it is optional), so the client
                 should page through the results in another way.""")
@@ -658,7 +660,9 @@ class CatalogueServiceWeb(object):
 
         if isinstance(self.request, six.string_types):  # GET KVP
             self.request = '%s%s' % (bind_url(request_url), self.request)
-            self.response = openURL(self.request, None, 'Get', username=self.username, password=self.password, timeout=self.timeout).read()
+            self.response = openURL(
+                self.request, None, 'Get', timeout=self.timeout, auth=self.auth
+            ).read()
         else:
             self.request = cleanup_namespaces(self.request)
             # Add any namespaces used in the "typeNames" attribute of the
@@ -674,7 +678,7 @@ class CatalogueServiceWeb(object):
 
             self.request = util.element_to_string(self.request, encoding='utf-8')
 
-            self.response = util.http_post(request_url, self.request, self.lang, self.timeout, self.username, self.password)
+            self.response = http_post(request_url, self.request, self.lang, self.timeout, auth=self.auth)
 
         # parse result see if it's XML
         self._exml = etree.parse(BytesIO(self.response))

--- a/owslib/feature/__init__.py
+++ b/owslib/feature/__init__.py
@@ -14,11 +14,14 @@ try:
 except ImportError:
     from urllib.parse import urlencode
 import logging
-from owslib.util import log
+from owslib.util import log, Authentication
 from owslib.feature.schema import get_schema
 
 class WebFeatureService_(object):
     """Base class for WebFeatureService implementations"""
+
+    def __init__(self, auth=None):
+        self.auth = auth or Authentication()
 
     def getBBOXKVP (self,bbox,typename):
         """Formate bounding box for KVP request type (HTTP GET)
@@ -162,12 +165,8 @@ class WebFeatureService_(object):
 
         return base_url+data
 
-
     def get_schema(self, typename):
         """
         Get layer schema compatible with :class:`fiona` schema object
         """
-
-        return get_schema(self.url, typename, self.version)
-    
-
+        return get_schema(self.url, typename, self.version, auth=self.auth)

--- a/owslib/feature/wfs300.py
+++ b/owslib/feature/wfs300.py
@@ -10,9 +10,9 @@ import json
 import logging
 
 from six.moves.urllib.parse import urljoin
-import requests
 
 from owslib import __version__
+from owslib.util import Authentication, http_get
 
 LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ REQUEST_HEADERS = {
 class WebFeatureService_3_0_0(object):
     """Abstraction for OGC Web Feature Service (WFS) version 3.0"""
     def __init__(self, url, version, json_, timeout=30, username=None,
-                 password=None):
+                 password=None, auth=None):
         """
         initializer; implements Requirement 1 (/req/core/root-op)
 
@@ -36,6 +36,7 @@ class WebFeatureService_3_0_0(object):
         @param timeout: time (in seconds) after which requests should timeout
         @param username: service authentication username
         @param password: service authentication password
+        @param auth: instance of owslib.util.Authentication
 
         @return: initialized WebFeatureService_3_0_0 object
         """
@@ -49,13 +50,17 @@ class WebFeatureService_3_0_0(object):
         self.version = version
         self.json_ = json_
         self.timeout = timeout
-        self.username = username
-        self.password = password
+        if auth:
+            if username:
+                auth.username = username
+            if password:
+                auth.password = password
+        self.auth = auth or Authentication(username, password)
 
         if json_ is not None:  # static JSON string
             self.links = json.loads(json_)['links']
         else:
-            response = requests.get(url, headers=REQUEST_HEADERS, auth=(self.username, self.password)).json()
+            response = http_get(url, headers=REQUEST_HEADERS, auth=self.auth).json()
             self.links = response['links']
 
     def api(self):
@@ -67,7 +72,7 @@ class WebFeatureService_3_0_0(object):
 
         url = self._build_url('api')
         LOGGER.debug('Request: {}'.format(url))
-        response = requests.get(url, headers=REQUEST_HEADERS, auth=(self.username, self.password)).json()
+        response = http_get(url, headers=REQUEST_HEADERS, auth=self.auth).json()
         return response
 
     def conformance(self):
@@ -79,7 +84,7 @@ class WebFeatureService_3_0_0(object):
 
         url = self._build_url('conformance')
         LOGGER.debug('Request: {}'.format(url))
-        response = requests.get(url, headers=REQUEST_HEADERS, auth=(self.username, self.password)).json()
+        response = http_get(url, headers=REQUEST_HEADERS, auth=self.auth).json()
         return response
 
     def collections(self):
@@ -91,7 +96,7 @@ class WebFeatureService_3_0_0(object):
 
         url = self._build_url('collections')
         LOGGER.debug('Request: {}'.format(url))
-        response = requests.get(url, headers=REQUEST_HEADERS, auth=(self.username, self.password)).json()
+        response = http_get(url, headers=REQUEST_HEADERS, auth=self.auth).json()
         return response['collections']
 
     def collection(self, collection_name):
@@ -107,7 +112,7 @@ class WebFeatureService_3_0_0(object):
         path = 'collections/{}'.format(collection_name)
         url = self._build_url(path)
         LOGGER.debug('Request: {}'.format(url))
-        response = requests.get(url, headers=REQUEST_HEADERS, auth=(self.username, self.password)).json()
+        response = http_get(url, headers=REQUEST_HEADERS, auth=self.auth).json()
         return response
 
     def collection_items(self, collection_name, **kwargs):
@@ -134,8 +139,7 @@ class WebFeatureService_3_0_0(object):
         path = 'collections/{}/items'.format(collection_name)
         url = self._build_url(path)
         LOGGER.debug('Request: {}'.format(url))
-        response = requests.get(url, headers=REQUEST_HEADERS, auth=(self.username, self.password),
-                                params=kwargs).json()
+        response = http_get(url, headers=REQUEST_HEADERS, params=kwargs, auth=self.auth).json()
         return response
 
     def collection_item(self, collection_name, identifier):
@@ -153,7 +157,7 @@ class WebFeatureService_3_0_0(object):
         path = 'collections/{}/items/{}'.format(collection_name, identifier)
         url = self._build_url(path)
         LOGGER.debug('Request: {}'.format(url))
-        response = requests.get(url, headers=REQUEST_HEADERS, auth=(self.username, self.password)).json()
+        response = http_get(url, headers=REQUEST_HEADERS, auth=self.auth).json()
         return response
 
     def _build_url(self, path=None):

--- a/owslib/map/wms111.py
+++ b/owslib/map/wms111.py
@@ -30,7 +30,7 @@ import six
 from owslib.etree import etree
 from owslib.util import (openURL, testXMLValue, extract_xml_list,
                          xmltag_split, OrderedDict, ServiceException,
-                         bind_url, nspath_eval)
+                         bind_url, nspath_eval, Authentication)
 from owslib.fgdc import Metadata
 from owslib.iso import MD_Metadata
 from owslib.map.common import WMSCapabilitiesReader, AbstractContentMetadata
@@ -57,25 +57,24 @@ class WebMapService_1_1_1(object):
         else:
             raise KeyError("No content named %s" % name)
 
-    def __init__(self, url, version='1.1.1', xml=None,
-                 username=None,
-                 password=None,
-                 parse_remote_metadata=False,
-                 headers=None,
-                 timeout=30):
+    def __init__(self, url, version='1.1.1', xml=None, username=None, password=None,
+                 parse_remote_metadata=False, headers=None, timeout=30, auth=None):
         """Initialize."""
+        if auth:
+            if username:
+                auth.username = username
+            if password:
+                auth.password = password
         self.url = url
-        self.username = username
-        self.password = password
         self.version = version
         self.timeout = timeout
         self.headers = headers
         self._capabilities = None
+        self.auth = auth or Authentication(username, password)
 
         # Authentication handled by Reader
-        reader = WMSCapabilitiesReader(self.version, url=self.url,
-                                       un=self.username, pw=self.password,
-                                       headers=headers)
+        reader = WMSCapabilitiesReader(
+            self.version, url=self.url, headers=headers, auth=self.auth)
         if xml:  # read from stored xml
             self._capabilities = reader.readString(xml)
         else:  # read from server
@@ -149,8 +148,7 @@ class WebMapService_1_1_1(object):
         NOTE: this is effectively redundant now"""
 
         reader = WMSCapabilitiesReader(
-            self.version, url=self.url, un=self.username, pw=self.password
-        )
+            self.version, url=self.url, auth=self.auth)
         u = self._open(reader.capabilities_url(self.url))
         # check for service exceptions, and return
         if u.info()['Content-Type'] == 'application/vnd.ogc.se_xml':
@@ -266,7 +264,7 @@ class WebMapService_1_1_1(object):
 
         self.request = bind_url(base_url) + data
 
-        u = openURL(base_url, data, method, username=self.username, password=self.password, timeout=timeout or self.timeout)
+        u = openURL(base_url, data, method, timeout=timeout or self.timeout, auth=self.auth)
 
         # check for service exceptions, and return
         if u.info().get('Content-Type', '').split(';')[0] in ['application/vnd.ogc.se_xml']:
@@ -332,7 +330,7 @@ class WebMapService_1_1_1(object):
 
         self.request = bind_url(base_url) + data
 
-        u = openURL(base_url, data, method, username=self.username, password=self.password, timeout=timeout or self.timeout)
+        u = openURL(base_url, data, method, timeout=timeout or self.timeout, auth=self.auth)
 
         # check for service exceptions, and return
         if u.info()['Content-Type'] == 'application/vnd.ogc.se_xml':
@@ -410,7 +408,10 @@ class ContentMetadata(AbstractContentMetadata):
 
     Implements IContentMetadata.
     """
-    def __init__(self, elem, parent=None, children=None, index=0, parse_remote_metadata=False, timeout=30):
+
+    def __init__(self, elem, parent=None, children=None, index=0,
+                 parse_remote_metadata=False, timeout=30, auth=None):
+        super(ContentMetadata, self).__init__(auth)
         if elem.tag != 'Layer':
             raise ValueError('%s should be a Layer' % (elem,))
 
@@ -593,7 +594,8 @@ class ContentMetadata(AbstractContentMetadata):
             if metadataUrl['url'] is not None \
                     and metadataUrl['format'].lower() in ['application/xml', 'text/xml']:  # download URL
                 try:
-                    content = openURL(metadataUrl['url'], timeout=timeout)
+                    content = openURL(
+                        metadataUrl['url'], timeout=timeout, auth=self.auth)
                     doc = etree.fromstring(content.read())
 
                     if metadataUrl['type'] == 'FGDC':

--- a/owslib/swe/observation/sos100.py
+++ b/owslib/swe/observation/sos100.py
@@ -136,10 +136,7 @@ class SensorObservationService_1_0_0(object):
 
         data = urlencode(request)
 
-
         response = openURL(base_url, data, method, username=self.username, password=self.password, **url_kwargs).read()
-
-
 
         tr = etree.fromstring(response)
 

--- a/owslib/tms.py
+++ b/owslib/tms.py
@@ -18,7 +18,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from .etree import etree
-from .util import openURL, testXMLValue, ServiceException
+from .util import testXMLValue, ServiceException, Authentication, openURL
 
 
 FORCE900913 = False
@@ -40,11 +40,16 @@ class TileMapService(object):
     Implements IWebMapService.
     """
 
-    def __init__(self, url, version='1.0.0', xml=None, username=None, password=None, parse_remote_metadata=False, timeout=30):
+    def __init__(self, url, version='1.0.0', xml=None, username=None, password=None,
+                 parse_remote_metadata=False, timeout=30, auth=None):
         """Initialize."""
+        if auth:
+            if username:
+                auth.username = username
+            if password:
+                auth.password = password
         self.url = url
-        self.username = username
-        self.password = password
+        self.auth = auth or Authentication(username, password)
         self.version = version
         self.timeout = timeout
         self.services = None
@@ -85,7 +90,7 @@ class TileMapService(object):
         tilemaps = self._capabilities.find('TileMaps')
         if tilemaps is not None:
             for tilemap in tilemaps.findall('TileMap'):
-                cm = ContentMetadata(tilemap, un=self.username, pw=self.password)
+                cm = ContentMetadata(tilemap, auth=self.auth)
                 if cm.id:
                     if cm.id in self.contents:
                         raise KeyError('Content metadata for layer "%s" already exists' % cm.id)
@@ -113,7 +118,7 @@ class TileMapService(object):
                 if self.contents[item].srs == srs:
                     items.append((item,self.contents[item]))
         elif profile:
-             for item in self.contents:
+            for item in self.contents:
                 if self.contents[item].profile == profile:
                     items.append((item,self.contents[item]))
         return items
@@ -122,8 +127,7 @@ class TileMapService(object):
         for tileset in tilesets:
             if tileset['order'] == z:
                 url = tileset['href'] + '/' + str(x) +'/' + str(y) + '.' + ext
-                u = openURL(url, '', username = self.username,
-                            password = self.password, timeout=timeout or self.timeout)
+                u = openURL(url, '', timeout=timeout or self.timeout, auth=self.auth)
                 return u
         else:
             raise ValueError('cannot find zoomlevel %i for TileMap' % z)
@@ -180,24 +184,27 @@ class ContentMetadata(object):
     def __str__(self):
         return 'Layer Title: %s, URL: %s' % (self.title, self.id)
 
-    def __init__(self, elem, un=None, pw=None):
+    def __init__(self, elem, un=None, pw=None, auth=None):
         if elem.tag != 'TileMap':
             raise ValueError('%s should be a TileMap' % (elem,))
         self.id = elem.attrib['href']
         self.title = elem.attrib['title']
         self.srs = force900913(elem.attrib['srs'])
         self.profile = elem.attrib['profile']
-        self.password = pw
-        self.username = pw
+        if auth:
+            if un:
+                auth.username = un
+            if pw:
+                auth.password = pw
+        self.auth = auth or Authentication(un, pw)
         self._tile_map = None
         self.type = elem.attrib.get('type')
 
     def _get_tilemap(self):
         if self._tile_map is None:
-            self._tile_map = TileMap(self.id, un=self.username, pw=self.password)
+            self._tile_map = TileMap(self.id, auth=self.auth)
             assert(self._tile_map.srs == self.srs)
         return self._tile_map
-
 
     @property
     def tilemap(self):
@@ -249,16 +256,19 @@ class TileMap(object):
     tilesets = None
     profile = None
 
-    def __init__(self, url=None, xml=None, un=None, pw=None):
+    def __init__(self, url=None, xml=None, un=None, pw=None, auth=None):
         self.url = url
-        self.username = un
-        self.password = pw
+        if auth:
+            if un:
+                auth.username = un
+            if pw:
+                auth.password = pw
+        self.auth = auth or Authentication(un, pw)
         self.tilesets = []
         if xml and not url:
             self.readString(xml)
         elif url:
             self.read(url)
-
 
     def _parse(self, elem):
         if elem.tag != 'TileMap':
@@ -296,7 +306,7 @@ class TileMap(object):
                     'order': order})
 
     def read(self, url):
-        u = openURL(url, '', method='Get', username = self.username, password = self.password)
+        u = openURL(url, '', method='Get', auth=self.auth)
         self._parse(etree.fromstring(u.read()))
 
     def readString(self, st):
@@ -310,20 +320,23 @@ class TMSCapabilitiesReader(object):
     """Read and parse capabilities document into a lxml.etree infoset
     """
 
-    def __init__(self, version='1.0.0', url=None, un=None, pw=None):
+    def __init__(self, version='1.0.0', url=None, un=None, pw=None, auth=None):
         """Initialize"""
+        if auth:
+            if un:
+                auth.username = un
+            if pw:
+                auth.password = pw
         self.version = version
         self._infoset = None
         self.url = url
-        self.username = un
-        self.password = pw
-
+        self.auth = auth or Authentication(un, pw)
 
     def read(self, service_url, timeout=30):
         """Get and parse a TMS capabilities document, returning an
         elementtree instance
         """
-        u = openURL(service_url, '', method='Get', username=self.username, password=self.password, timeout=timeout)
+        u = openURL(service_url, '', method='Get', timeout=timeout, auth=self.auth)
         return etree.fromstring(u.read())
 
     def readString(self, st):

--- a/owslib/util.py
+++ b/owslib/util.py
@@ -9,6 +9,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+import os
 import sys
 from collections import OrderedDict
 from dateutil import parser
@@ -17,6 +18,7 @@ import pytz
 from owslib.etree import etree, ParseError
 from owslib.namespaces import Namespaces
 from six.moves.urllib.parse import urlsplit, urlencode, urlparse, parse_qs, urlunparse
+import copy
 
 try:
     from StringIO import StringIO  # Python 2
@@ -135,7 +137,7 @@ class ResponseWrapper(object):
     # @TODO: __getattribute__ for poking at response
 
 def openURL(url_base, data=None, method='Get', cookies=None, username=None, password=None, timeout=30, headers=None,
-            verify=True, cert=None):
+            verify=True, cert=None, auth=None):
     """
     Function to open URLs.
 
@@ -147,6 +149,7 @@ def openURL(url_base, data=None, method='Get', cookies=None, username=None, pass
                    Defaults to ``True``.
     :param cert: (optional) A file with a client side certificate for SSL authentication
                  to send with the :class:`Request`.
+    :param auth: Instance of owslib.util.Authentication
     """
 
     headers = headers if headers is not None else {}
@@ -154,11 +157,21 @@ def openURL(url_base, data=None, method='Get', cookies=None, username=None, pass
 
     rkwargs['timeout'] = timeout
 
-    auth = None
-    if username and password:
-        auth = (username, password)
-
-    rkwargs['auth'] = auth
+    if auth:
+        if username:
+            auth.username = username
+        if password:
+            auth.password = password
+        if cert:
+            auth.cert = cert
+        if verify and not auth.verify:
+            auth.verify = verify
+    else:
+        auth = Authentication(username, password, cert, verify)
+    if auth.username and auth.password:
+        rkwargs['auth'] = (auth.username, auth.password)
+    rkwargs['cert'] = auth.cert
+    rkwargs['verify'] = auth.verify
 
     # FIXUP for WFS in particular, remove xml style namespace
     # @TODO does this belong here?
@@ -166,7 +179,7 @@ def openURL(url_base, data=None, method='Get', cookies=None, username=None, pass
 
     if method.lower() == 'post':
         try:
-            xml = etree.fromstring(data)
+            etree.fromstring(data)
             headers['Content-Type'] = 'text/xml'
         except (ParseError, UnicodeEncodeError):
             pass
@@ -182,12 +195,7 @@ def openURL(url_base, data=None, method='Get', cookies=None, username=None, pass
     if cookies is not None:
         rkwargs['cookies'] = cookies
 
-    req = requests.request(method.upper(),
-                           url_base,
-                           headers=headers,
-                           verify=verify,
-                           cert=cert,
-                           **rkwargs)
+    req = requests.request(method.upper(), url_base, headers=headers, **rkwargs)
 
     if req.status_code in [400, 401]:
         raise ServiceException(req.text)
@@ -358,7 +366,7 @@ def testXMLAttribute(element, attribute):
 
     return None
 
-def http_post(url=None, request=None, lang='en-US', timeout=10, username=None, password=None):
+def http_post(url=None, request=None, lang='en-US', timeout=10, username=None, password=None, auth=None):
     """
 
     Invoke an HTTP POST request
@@ -389,11 +397,51 @@ def http_post(url=None, request=None, lang='en-US', timeout=10, username=None, p
 
     rkwargs = {}
 
-    if username is not None and password is not None:
-        rkwargs['auth'] = (username, password)
+    if auth:
+        if username:
+            auth.username = username
+        if password:
+            auth.password = password
+    else:
+        auth = Authentication(username, password)
+    if auth.username is not None and auth.password is not None:
+        rkwargs['auth'] = (auth.username, auth.password)
+    rkwargs['verify'] = auth.verify
+    rkwargs['cert'] = auth.cert
 
     up = requests.post(url, request, headers=headers, **rkwargs)
     return up.content
+
+def http_get(*args, **kwargs):
+    # Copy input kwargs so the dict can be modified
+    rkwargs = copy.deepcopy(kwargs)
+
+    # Use Authentication instance if provided, else create one
+    auth = rkwargs.pop('auth', None)
+    if auth is not None:
+        if isinstance(auth, (tuple, list)):
+            auth = Authentication(*auth)
+    else:
+        auth = Authentication()
+
+    # Populate values with other arguments supplied
+    if 'username' in rkwargs:
+        auth.username = rkwargs.pop('username')
+    if 'password' in rkwargs:
+        auth.password = rkwargs.pop('password')
+    if 'cert' in rkwargs:
+        auth.cert = rkwargs.pop('cert')
+    if 'verify' in rkwargs:
+        auth.verify = rkwargs.pop('verify')
+
+    # Build keyword args for call to requests.get()
+    if auth.username and auth.password:
+        rkwargs.setdefault('auth', (auth.username, auth.password))
+    else:
+        rkwargs.setdefault('auth', None)
+    rkwargs.setdefault('cert', rkwargs.get('cert'))
+    rkwargs.setdefault('verify', rkwargs.get('verify', True))
+    return requests.get(*args, **rkwargs)
 
 def element_to_string(element, encoding=None, xml_declaration=False):
     """
@@ -735,3 +783,135 @@ def encode_string(text):
     if isinstance(text, str):
         return text.decode('utf-8').encode('utf-8', 'ignore')
     return text.encode('utf-8', 'ignore')
+
+
+class Authentication(object):
+
+    _USERNAME = None
+    _PASSWORD = None
+    _CERT = None
+    _VERIFY = None
+
+    def __init__(self, username=None, password=None,
+                 cert=None, verify=True, shared=False):
+        '''
+        :param str username=None: Username for basic authentication, None for
+            unauthenticated access (or if using cert/verify)
+        :param str password=None: Password for basic authentication, None for
+            unauthenticated access (or if using cert/verify)
+        :param cert=None: Either a str (path to a combined certificate/key) or
+            tuple/list of paths (certificate, key). If supplied, the target
+            files must exist.
+        :param verify=True: Either a bool (verify SSL certificates, use system
+            CA bundle) or str (path to a specific CA bundle). If a str, the
+            target file must exist.
+        :param bool shared=False: Set to True to make the values be class-level
+            attributes (shared among instances where shared=True) instead of
+            instance-level (shared=False, default)
+        '''
+        self.shared = shared
+        self.username = username
+        self.password = password
+        self.cert = cert
+        self.verify = verify
+
+    @property
+    def username(self):
+        if self.shared:
+            return self._USERNAME
+        return self._username
+
+    @username.setter
+    def username(self, value):
+        if value is None:
+            pass
+        elif not isinstance(value, str):
+            raise TypeError('Value for "username" must be a str')
+        if self.shared:
+            self.__class__._USERNAME = value
+        else:
+            self._username = value
+
+    @property
+    def password(self):
+        if self.shared:
+            return self._PASSWORD
+        return self._username
+
+    @password.setter
+    def password(self, value):
+        if value is None:
+            pass
+        elif not isinstance(value, str):
+            raise TypeError('Value for "password" must be a str')
+        if self.shared:
+            self.__class__._PASSWORD = value
+        else:
+            self._password = value
+
+    @property
+    def cert(self):
+        if self.shared:
+            return self._CERT
+        return self._cert
+
+    @cert.setter
+    def cert(self, certificate, key=None):
+        error = 'Value for "cert" must be a str path to a file or list/tuple of str paths'
+        value = None
+        if certificate is None:
+            value = certificate
+        elif isinstance(certificate, (list, tuple)):
+            for _ in certificate:
+                if not isinstance(_, str):
+                    raise TypeError(error)
+                os.stat(_)  # Raises OSError/FileNotFoundError if missing
+            # Both paths supplied as same argument
+            value = tuple(certificate)
+        elif isinstance(certificate, str):
+            os.stat(certificate)  # Raises OSError/FileNotFoundError if missing
+            if isinstance(key, str):
+                # Separate files for certificate and key
+                value = (certificate, key)
+            else:
+                # Assume combined file of both certificate and key
+                value = certificate
+        else:
+            raise TypeError(error)
+        if self.shared:
+            self.__class__._CERT = value
+        else:
+            self._cert = value
+
+    @property
+    def verify(self):
+        if self.shared:
+            return self._VERIFY
+        return self._verify
+
+    @verify.setter
+    def verify(self, value):
+        if value is None:
+            pass  # Passthrough when clearing the value
+        elif not isinstance(value, (bool, str)):
+            raise TypeError(
+                'Value for "verify" must a bool or str path to a file')
+        elif isinstance(value, str):
+            os.stat(value)  # Raises OSError/FileNotFoundError if missing
+        if self.shared:
+            self.__class__._VERIFY = value
+        else:
+            self._verify = value
+
+    @property
+    def urlopen_kwargs(self):
+        return {
+            'username': self.username,
+            'password': self.password,
+            'cert': self.cert,
+            'verify': self.verify
+        }
+
+    def __repr__(self, *args, **kwargs):
+        return '<{} shared={} username={} password={} cert={} verify={}>'.format(
+            self.__class__.__name__, self.shared, self.username, self.password, self.cert, self.verify)

--- a/owslib/wcs.py
+++ b/owslib/wcs.py
@@ -17,17 +17,21 @@ from __future__ import (absolute_import, division, print_function)
 
 from . import etree
 from .coverage import wcs100, wcs110, wcs111, wcsBase, wcs200, wcs201
-from owslib.util import clean_ows_url, openURL
+from owslib.util import clean_ows_url, Authentication, openURL
 
 
-def WebCoverageService(url, version=None, xml=None, cookies=None, timeout=30):
+def WebCoverageService(url, version=None, xml=None, cookies=None, timeout=30, auth=None):
     ''' wcs factory function, returns a version specific WebCoverageService object '''
+
+    if not auth:
+        auth = Authentication()
 
     if version is None:
         if xml is None:
-            reader = wcsBase.WCSCapabilitiesReader()
+            reader = wcsBase.WCSCapabilitiesReader(auth=auth)
             request = reader.capabilities_url(url)
-            xml = openURL(request, cookies=cookies, timeout=timeout).read()
+            xml = openURL(
+                request, cookies=cookies, timeout=timeout, auth=auth).read()
 
         capabilities = etree.etree.fromstring(xml)
         version = capabilities.get('version')
@@ -36,12 +40,17 @@ def WebCoverageService(url, version=None, xml=None, cookies=None, timeout=30):
     clean_url = clean_ows_url(url)
 
     if version == '1.0.0':
-        return wcs100.WebCoverageService_1_0_0.__new__(wcs100.WebCoverageService_1_0_0, clean_url, xml, cookies)
+        return wcs100.WebCoverageService_1_0_0.__new__(
+            wcs100.WebCoverageService_1_0_0, clean_url, xml, cookies, auth=auth)
     elif version == '1.1.0':
-        return wcs110.WebCoverageService_1_1_0.__new__(wcs110.WebCoverageService_1_1_0, url, xml, cookies)
+        return wcs110.WebCoverageService_1_1_0.__new__(
+            wcs110.WebCoverageService_1_1_0, url, xml, cookies, auth=auth)
     elif version == '1.1.1':
-        return wcs111.WebCoverageService_1_1_1.__new__(wcs111.WebCoverageService_1_1_1, url, xml, cookies)
+        return wcs111.WebCoverageService_1_1_1.__new__(
+            wcs111.WebCoverageService_1_1_1, url, xml, cookies, auth=auth)
     elif version == '2.0.0':
-        return wcs200.WebCoverageService_2_0_0.__new__(wcs200.WebCoverageService_2_0_0, url, xml, cookies)
+        return wcs200.WebCoverageService_2_0_0.__new__(
+            wcs200.WebCoverageService_2_0_0, url, xml, cookies, auth=auth)
     elif version == '2.0.1':
-        return wcs201.WebCoverageService_2_0_1.__new__(wcs201.WebCoverageService_2_0_1, url, xml, cookies)
+        return wcs201.WebCoverageService_2_0_1.__new__(
+            wcs201.WebCoverageService_2_0_1, url, xml, cookies, auth=auth)

--- a/owslib/wfs.py
+++ b/owslib/wfs.py
@@ -16,12 +16,12 @@ Web Feature Server (WFS) methods and metadata. Factory function.
 from __future__ import (absolute_import, division, print_function)
 
 from .feature import wfs100, wfs110, wfs200, wfs300
-from .util import clean_ows_url
+from .util import clean_ows_url, Authentication
 
 
 def WebFeatureService(url, version='1.0.0', xml=None, json_=None,
                       parse_remote_metadata=False, timeout=30, username=None,
-                      password=None):
+                      password=None, auth=None):
     ''' wfs factory function, returns a version specific WebFeatureService object
 
     @type url: string
@@ -33,28 +33,27 @@ def WebFeatureService(url, version='1.0.0', xml=None, json_=None,
     @param timeout: time (in seconds) after which requests should timeout
     @param username: service authentication username
     @param password: service authentication password
+    @param auth: instance of owslib.util.Authentication
     @return: initialized WebFeatureService object (version dependent)
     '''
-
+    if auth:
+        if username:
+            auth.username = username
+        if password:
+            auth.password = password
+    else:
+        auth = Authentication(username, password)
     clean_url = clean_ows_url(url)
 
-    if version in  ['1.0', '1.0.0']:
-        return wfs100.WebFeatureService_1_0_0(clean_url, version, xml, parse_remote_metadata,
-                                              timeout=timeout,
-                                              username=username,
-                                              password=password)
-    elif version in  ['1.1', '1.1.0']:
-        return wfs110.WebFeatureService_1_1_0(clean_url, version, xml, parse_remote_metadata,
-                                              timeout=timeout,
-                                              username=username,
-                                              password=password)
+    if version in ['1.0', '1.0.0']:
+        return wfs100.WebFeatureService_1_0_0(
+            clean_url, version, xml, parse_remote_metadata, timeout=timeout, auth=auth)
+    elif version in ['1.1', '1.1.0']:
+        return wfs110.WebFeatureService_1_1_0(
+            clean_url, version, xml, parse_remote_metadata, timeout=timeout, auth=auth)
     elif version in ['2.0', '2.0.0']:
-        return wfs200.WebFeatureService_2_0_0(clean_url, version, xml, parse_remote_metadata,
-                                              timeout=timeout,
-                                              username=username,
-                                              password=password)
+        return wfs200.WebFeatureService_2_0_0(
+            clean_url, version, xml, parse_remote_metadata, timeout=timeout, auth=auth)
     elif version in ['3.0', '3.0.0']:
-        return wfs300.WebFeatureService_3_0_0(clean_url, version, json_,
-                                              timeout=timeout,
-                                              username=username,
-                                              password=password)
+        return wfs300.WebFeatureService_3_0_0(
+            clean_url, version, json_, timeout=timeout, auth=auth)

--- a/owslib/wms.py
+++ b/owslib/wms.py
@@ -17,17 +17,11 @@ Currently supports only version 1.1.1 of the WMS protocol.
 
 from __future__ import (absolute_import, division, print_function)
 from .map import wms111, wms130
-from .util import clean_ows_url
+from .util import clean_ows_url, Authentication
 
 
-def WebMapService(url,
-                  version='1.1.1',
-                  xml=None,
-                  username=None,
-                  password=None,
-                  parse_remote_metadata=False,
-                  timeout=30,
-                  headers=None):
+def WebMapService(url, version='1.1.1', xml=None, username=None, password=None,
+                  parse_remote_metadata=False, timeout=30, headers=None, auth=None):
 
     '''wms factory function, returns a version specific WebMapService object
 
@@ -38,20 +32,26 @@ def WebMapService(url,
     @type parse_remote_metadata: boolean
     @param parse_remote_metadata: whether to fully process MetadataURL elements
     @param timeout: time (in seconds) after which requests should timeout
+    @param username: service authentication username
+    @param password: service authentication password
+    @param auth: instance of owslib.util.Authentication
     @return: initialized WebFeatureService_2_0_0 object
     '''
-
+    if auth:
+        if username:
+            auth.username = username
+        if password:
+            auth.password = password
+    else:
+        auth = Authentication(username, password)
     clean_url = clean_ows_url(url)
 
     if version in ['1.1.1']:
-        return wms111.WebMapService_1_1_1(clean_url, version=version, xml=xml,
-                                          parse_remote_metadata=parse_remote_metadata,
-                                          username=username, password=password,
-                                          timeout=timeout, headers=headers)
+        return wms111.WebMapService_1_1_1(
+            clean_url, version=version, xml=xml, parse_remote_metadata=parse_remote_metadata,
+            timeout=timeout, auth=auth)
     elif version in ['1.3.0']:
-        return wms130.WebMapService_1_3_0(clean_url, version=version, xml=xml,
-                                          parse_remote_metadata=parse_remote_metadata,
-                                          username=username, password=password,
-                                          timeout=timeout, headers=headers)
+        return wms130.WebMapService_1_3_0(
+            clean_url, version=version, xml=xml, parse_remote_metadata=parse_remote_metadata,
+            timeout=timeout, headers=headers, auth=auth)
     raise NotImplementedError('The WMS version (%s) you requested is not implemented. Please use 1.1.1 or 1.3.0.' % version)
-


### PR DESCRIPTION
* add username/password/cert/verify for WMS classes

* add WMTS cert/verify capability

* add username/password/cert/verify to WCS classes

* add username/password/cert/verify to WFS classes

* wmts/tms/wcs/wfs/wms should now support username/password/cert/verify

* returns 11 collections, verified using browser

new collection since test was written is "Dutch addresses (subset
Otterlo). OGR GeoPackage Driver" at
https://demo.pygeoapi.io/master/collections/ogr_addresses_gpkg

test now passes

* updated layer to one that exists

neither layer in the test exists on this GeoServer
using a new layer that does exist
also added checks for Exception in the string to be clearer about
expected results

* update version to 0.17.2

* default should be verify=True

* versions back to previous until formal release

* add Authentication class for local/global auth usage

change calls to openURL or requests.get/post to use the auth instance.
this automatically attacheds username/password/cert/verify to requests.

* pass auth instance to openURL, only overwrite verify if not set

* remove extra import, resolve conflict for test

* typo cookie -> cookies

* use auth in new api() function

function was added in bd0eded6488dc98ff35226ec094d7d2920e0bc39

* pass Authentication instance to functions instead of using auth.openURL